### PR TITLE
add another make target that just generates models for cd/ci pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ generate_models: generate_models_only
 	@echo "Ignore errors from pre-commit, they are expected"
 
 .PHONY: generate_models_only
-generate_models_only: venv  ## Generate new app models.py file
+generate_models_standalone: venv  ## Generate new app models.py file
 	$(WITH_VENV) python app/manage.py inspectdb --database milmove > new_models.py
 	mv new_models.py app/milmove_app/models.py
 

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ generate_models: venv  ## Generate new app models.py file
 	@echo "Ignore errors from pre-commit, they are expected"
 
 .PHONY: generate_models_standalone
-generate_models_standalone:
+generate_models_standalone: ## Generate new app models.py file without virtualenv or pre-commit
 	python app/manage.py inspectdb --database milmove > new_models.py
 	mv new_models.py app/milmove_app/models.py
 

--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,15 @@ migrate: venv  ## Migrate the database
 	$(WITH_VENV) python app/manage.py migrate
 
 .PHONY: generate_models
-generate_models: venv  ## Generate new app models.py file
-	$(WITH_VENV) python app/manage.py inspectdb --database milmove > new_models.py
-	mv new_models.py app/milmove_app/models.py
+generate_models: generate_models_only
 	pre-commit run --all-files black || true
 	pre-commit run --all-files fix-encoding-pragma || true
 	@echo "Ignore errors from pre-commit, they are expected"
+
+.PHONY: generate_models_only
+generate_models_only: venv  ## Generate new app models.py file
+	$(WITH_VENV) python app/manage.py inspectdb --database milmove > new_models.py
+	mv new_models.py app/milmove_app/models.py
 
 .PHONY: prepare_key
 prepare_key: venv  ## Creates a key in JWK format for use by django-oidc library

--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,16 @@ migrate: venv  ## Migrate the database
 	$(WITH_VENV) python app/manage.py migrate
 
 .PHONY: generate_models
-generate_models: generate_models_only
+generate_models: venv  ## Generate new app models.py file
+	$(WITH_VENV) python app/manage.py inspectdb --database milmove > new_models.py
+	mv new_models.py app/milmove_app/models.py
 	pre-commit run --all-files black || true
 	pre-commit run --all-files fix-encoding-pragma || true
 	@echo "Ignore errors from pre-commit, they are expected"
 
-.PHONY: generate_models_only
-generate_models_standalone: venv  ## Generate new app models.py file
-	$(WITH_VENV) python app/manage.py inspectdb --database milmove > new_models.py
+.PHONY: generate_models_standalone
+generate_models_standalone:
+	python app/manage.py inspectdb --database milmove > new_models.py
 	mv new_models.py app/milmove_app/models.py
 
 .PHONY: prepare_key


### PR DESCRIPTION
## Description

As part of another [PR](https://github.com/transcom/mymove/pull/3581) that is adding milmove admin to the ci pipeline this PR intends to add a simpler model generator so we dont have to worry about pre-commit hooks.

## Helpful Links
* Jira [Story](https://dp3.atlassian.net/browse/MB-1682?atlOrigin=eyJpIjoiMDg2MWVkNDQ3YzY4NDNhNjlkMmViNWJkOTBmYTg1MGUiLCJwIjoiaiJ9)