### PR TITLE
Force docker image to stay on alpine 3.11

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,5 +1,5 @@
 # pull official base image
-FROM python:3.8.0-alpine as builder
+FROM python:3.8-alpine3.11 as builder
 
 # set work directory
 WORKDIR /usr/src/app

--- a/app/Dockerfile.migrations
+++ b/app/Dockerfile.migrations
@@ -3,7 +3,7 @@
 ###########
 
 # pull official base image
-FROM python:3.8.0-alpine as builder
+FROM python:3.8-alpine3.11 as builder
 
 # set work directory
 WORKDIR /usr/src/app
@@ -27,7 +27,7 @@ RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requir
 #########
 
 # pull official base image
-FROM python:3.8-alpine
+FROM python:3.8-alpine3.11
 
 # create directory for the app user
 RUN mkdir -p /home/app

--- a/app/Dockerfile.prod
+++ b/app/Dockerfile.prod
@@ -3,7 +3,7 @@
 ###########
 
 # pull official base image
-FROM python:3.8.0-alpine as builder
+FROM python:3.8-alpine3.11 as builder
 
 # set work directory
 WORKDIR /usr/src/app
@@ -27,7 +27,7 @@ RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requir
 #########
 
 # pull official base image
-FROM python:3.8-alpine
+FROM python:3.8-alpine3.11
 
 # create directory for the app user
 RUN mkdir -p /home/app

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
       context: ./app
       dockerfile: Dockerfile.prod
       cache_from:
-        - python:3.8-alpine
+        - python:3.8-alpine3.11
     command: milmove_admin.wsgi:application --name milmove_admin --bind 0.0.0.0:8000 --workers 3 --log-level info --error-logfile "-" --access-logfile "-"
     image: milmove_admin:latest
     stdin_open: true


### PR DESCRIPTION
The milmove master builds were breaking with this error: `UnsupportedImageError: The operating system 'alpine' version 'v3.12' is not supported.` in the `build_milmove_admin_app` job.  It appears that the generic `alpine` version of python may have switched to `alpine 3.12` recently, so this tags it explicitly with `alpine 3.11`.

Also, I removed the explicit `3.8.0` version of python and it's now just pointing to `3.8`.  I don't believe there's a tag explicitly for `python:3.8.0-alpine3.11`.  Hopefully getting the latest patch release of python automatically isn't a problem.